### PR TITLE
Add guard statement to ShowCursor call

### DIFF
--- a/main.c
+++ b/main.c
@@ -26,6 +26,7 @@ int main(void) {
     xi_select_events(XI_RawKeyPress);
     XEvent e;
     XGenericEventCookie *c;
+    int hidden = 0;
     while (!XNextEvent(d, &e)) {
         if (!XGetEventData(d, (c = &e.xcookie)))
             continue;
@@ -33,10 +34,14 @@ int main(void) {
             case XI_RawKeyPress:
                 xi_select_events(XI_RawMotion);
                 XFixesHideCursor(d, r);
+		hidden++;
                 break;
             case XI_RawMotion:
-                xi_select_events(XI_RawKeyPress);
-                XFixesShowCursor(d, r);
+                while (hidden > 0) {
+                    xi_select_events(XI_RawKeyPress);
+                    XFixesShowCursor(d, r);
+		    hidden--;
+		}
                 break;
         }
         XFreeEventData(d, c);


### PR DESCRIPTION
First, I would like to thank you for releasing this nice little program as an alternative to xbanish!

While testing out xhidecursor on my desktop, I noticed that in cases where mouse and keyboard events are occurring in rapid succession (in other words, keyboard mashing while moving a mouse), it is possible for the ShowCursor call to fire before a HideCursor call has completed, leading to a BadMatch error.

When I attempted to fix this bug, I realized that it may also be possible for multiple HideCursor calls to occur before a ShowCursor call (which cancels out a single HideCursor call), leading to the cursor being stuck in a hidden state.

I used a guard statement/loop to prevent premature ShowCursor calls and call ShowCursor the correct number of times to mitigate both issues.

I am not the most experienced with release-quality C code, so feel free to let me know if there is anything I may need to adjust.