### PR TITLE
Add xhidecursor(1) manual page and install rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-PREFIX ?= /usr/local/bin
+PREFIX  ?= /usr/local
+BINDIR  ?= $(PREFIX)/bin
+MANDIR  ?= $(PREFIX)/share/man/man1
 
 CFLAGS += -std=c99 -march=native -O3 -pipe
 CFLAGS += -Wall
@@ -16,12 +18,15 @@ xhidecursor: main.c Makefile
 	$(CC) $(CFLAGS) -o $@ $< -lX11 -lXfixes -lXi
 
 install: all
-	install -D xhidecursor $(DESTDIR)$(PREFIX)/xhidecursor
+	install -D xhidecursor $(DESTDIR)$(BINDIR)/xhidecursor
+	install -D -m 644 xhidecursor.1 $(DESTDIR)$(MANDIR)/xhidecursor.1
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/xhidecursor
+	rm -f $(DESTDIR)$(BINDIR)/xhidecursor
+	rm -f $(DESTDIR)$(MANDIR)/xhidecursor.1
 
 clean:
 	rm -f xhidecursor
 
 .PHONY: all install uninstall clean
+

--- a/xhidecursor.1
+++ b/xhidecursor.1
@@ -1,0 +1,32 @@
+.TH XHIDECURSOR 1 "February 2025" "xhidecursor" "User Commands"
+.SH NAME
+xhidecursor \- hide the mouse cursor when typing
+
+.SH SYNOPSIS
+.B xhidecursor
+
+.SH DESCRIPTION
+xhidecursor hides the mouse cursor when a key is pressed and shows it again
+when the mouse is moved. It uses the XFixes extension and implements only the
+minimal required event handling. Compared to xbanish (nearly 500 lines of
+code), xhidecursor is much smaller (~40 lines) and uses less CPU.
+
+.SH USAGE
+xhidecursor runs in the background for the duration of the X session. To
+start it automatically:
+
+.nf
+    xhidecursor &
+.fi
+
+Place this line in ~/.xinitrc or your window manager startup file.
+
+.SH REQUIREMENTS
+The XFixes extension must be available on the X server.
+
+.SH SEE ALSO
+.BR XFixes (3)
+
+.SH AUTHORS
+xhidecursor was written by Aleksandrs Stier <aleks.stier@icloud.com>.
+


### PR DESCRIPTION
This PR adds a manual page for xhidecursor, following the simple and minimal
style used by similar X11 tools such as xbanish. The man page documents basic
usage, requirements, and authorship.

The Makefile is updated to install the man page into $(PREFIX)/share/man/man1,
using BINDIR and MANDIR variables. This keeps the build system portable and
allows distributions to package xhidecursor cleanly by overriding PREFIX and
DESTDIR.

Thanks for this useful minimal X11 tool!