### PR TITLE
improve Makefile portability and hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 PREFIX  ?= /usr/local
 BINDIR  ?= $(PREFIX)/bin
 MANDIR  ?= $(PREFIX)/share/man/man1
+CC      ?= cc
 
-CFLAGS += -std=c99 -march=native -O3 -pipe
+CFLAGS += -std=c99 -O3 -pipe
 CFLAGS += -Wall
 CFLAGS += -Wconversion
 CFLAGS += -Wdouble-promotion
@@ -11,11 +12,10 @@ CFLAGS += -Wmissing-prototypes
 CFLAGS += -Wold-style-definition
 CFLAGS += -Wpedantic
 CFLAGS += -Wshadow
-
 all: xhidecursor
 
 xhidecursor: main.c Makefile
-	$(CC) $(CFLAGS) -o $@ $< -lX11 -lXfixes -lXi
+	$(CC) $(CFLAGS) -o $@ main.c -lX11 -lXfixes -lXi
 
 install: all
 	install -D xhidecursor $(DESTDIR)$(BINDIR)/xhidecursor
@@ -29,4 +29,3 @@ clean:
 	rm -f xhidecursor
 
 .PHONY: all install uninstall clean
-


### PR DESCRIPTION
## Changes

- Make the compiler configurable with `CC ?= cc`.
- Remove non-portable `-march=native`.
- Replace GNU Make's `$<` with `main.c` for OpenBSD Make compatibility.

Distribution-specific hardening is intentionally left to package maintainers.

Fixes #8.

## Testing

Built successfully with:

- GCC 11.2.0
- Clang 13.0.0
- GCC 15.3.0
- Clang 22.1.8