### PR TITLE
Ignore modifier keys when hiding the cursor

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,3 +1,7 @@
+#include <X11/XKBlib.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/Xfixes.h>
 #include <X11/extensions/XInput2.h>
 
 #include <stdio.h>
@@ -18,29 +22,56 @@ void xi_select_events(const int event) {
 }
 
 int main(void) {
+    int fixes_event, fixes_error;
+    int xi_major = 2, xi_minor = 0;
+
     if (!(d = XOpenDisplay(NULL))) {
-        printf("Couldn't open Display.\n");
+        fprintf(stderr, "xhidecursor: couldn't open display %s\n",
+                XDisplayName(NULL));
         return 1;
     }
+    if (!XFixesQueryExtension(d, &fixes_event, &fixes_error)) {
+        fprintf(stderr, "xhidecursor: XFixes extension is unavailable\n");
+        XCloseDisplay(d);
+        return 1;
+    }
+    if (XIQueryVersion(d, &xi_major, &xi_minor) != Success) {
+        fprintf(stderr, "xhidecursor: XInput2 extension is unavailable\n");
+        XCloseDisplay(d);
+        return 1;
+    }
+
     r = XDefaultRootWindow(d);
     xi_select_events(XI_RawKeyPress);
     XEvent e;
-    XGenericEventCookie *c;
-    while (!XNextEvent(d, &e)) {
-        if (!XGetEventData(d, (c = &e.xcookie)))
+    while (XNextEvent(d, &e) == 0) {
+        if (e.type != GenericEvent ||
+            !XGetEventData(d, &e.xcookie))
             continue;
+
+        XGenericEventCookie *c = &e.xcookie;
         switch (c->evtype) {
-            case XI_RawKeyPress:
+            case XI_RawKeyPress: {
+                XIRawEvent *raw = (XIRawEvent *)c->data;
+                KeySym keysym = XkbKeycodeToKeysym(d, (KeyCode)raw->detail,
+                                                   0, 0);
+
+                if (IsModifierKey(keysym))
+                    break;
+
                 xi_select_events(XI_RawMotion);
                 XFixesHideCursor(d, r);
                 break;
+            }
             case XI_RawMotion:
                 xi_select_events(XI_RawKeyPress);
                 XFixesShowCursor(d, r);
                 break;
         }
         XFreeEventData(d, c);
+        /* Synchronize selection changes and discard stale events. */
         XSync(d, True);
     }
     XCloseDisplay(d);
+    return 0;
 }

--- a/xhidecursor.1
+++ b/xhidecursor.1
@@ -22,11 +22,10 @@ start it automatically:
 Place this line in ~/.xinitrc or your window manager startup file.
 
 .SH REQUIREMENTS
-The XFixes extension must be available on the X server.
+The XInput2 and XFixes extensions must be available on the X server.
 
 .SH SEE ALSO
 .BR XFixes (3)
 
 .SH AUTHORS
 xhidecursor was written by Aleksandrs Stier <aleks.stier@icloud.com>.
-


### PR DESCRIPTION
## Description

Do not hide the cursor when only a modifier key is pressed, such as
`CTRL`, `SHIFT`, `ALT`, or `SUPER`.

This also adds explicit X11 headers, checks for the required XInput2 and
XFixes extensions, improves display error messages, and validates generic
events before processing them.

The Makefile is unchanged. This PR is focused on cursor behavior and event
handling.

## Testing

- Built successfully with `make`
- Verified that modifier keys do not hide the cursor
- Verified that regular keys hide the cursor
- Verified that mouse movement shows the cursor again
- Stress-tested typing while moving the mouse
